### PR TITLE
Set rework `source` from `relativePath`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,10 @@ ReworkFilter.prototype.targetExtension = 'css';
  * @api public
  */
 
-ReworkFilter.prototype.processString = function (str) {
-    var rework = new Rework(str);
+ReworkFilter.prototype.processString = function (str, relativePath) {
+    var rework = new Rework(str, {
+      source: relativePath
+    });
 
     if (this.opts.use) {
         this.opts.use(rework);


### PR DESCRIPTION
This will enable sourcemaps generated from rework to refer to the source by its name, versus the generic `source.css`.
